### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/fc/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fc/projectboard/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString(callSuper = true)
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/fc/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fc/projectboard/repository/JpaRepositoryTest.java
@@ -47,7 +47,7 @@ class JpaRepositoryTest {
     @Test
     void givenTestData_whenInserting_thenWorksFine() {
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("user02", "pw1234", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("user03", "pw1234", null, null, null));
 
         Article article = articleRepository.save(Article.of(userAccount, "2 article", "2 content", ""));
         articleRepository.save(article);


### PR DESCRIPTION
회원 id로 로그인하고 유저 식별하므로, 당연히 uk 여야 한다.
이 부분이 설계에서 반영되지 않았던 것을 발견
테스트는 uk 적용으로 기존 `data.sql`의 테스트 데이터와
중복이 발생하므로 `userId` 이름을 수정