### PR TITLE
해시태그 고도화

### DIFF
--- a/src/main/java/com/fc/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fc/projectboard/controller/ArticleController.java
@@ -1,6 +1,5 @@
 package com.fc.projectboard.controller;
 
-
 import com.fc.projectboard.domain.constant.FormStatus;
 import com.fc.projectboard.domain.constant.SearchType;
 import com.fc.projectboard.dto.request.ArticleRequest;
@@ -42,6 +41,7 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -53,6 +53,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
@@ -39,5 +39,6 @@ public interface ArticleRepository extends
         bindings.bind(root.createdAt).first(DateTimeExpression::eq);
         bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
     }
+
 }
 

--- a/src/main/java/com/fc/projectboard/repository/HashtagRepository.java
+++ b/src/main/java/com/fc/projectboard/repository/HashtagRepository.java
@@ -13,6 +13,5 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long>,
         HashtagRepositoryCustom,
         QuerydslPredicateExecutor<Hashtag> {
     Optional<Hashtag> findByHashtagName(String hashtagName);
-
     List<Hashtag> findByHashtagNameIn(Set<String> hashtagNames);
 }

--- a/src/main/java/com/fc/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fc/projectboard/service/ArticleService.java
@@ -1,11 +1,13 @@
 package com.fc.projectboard.service;
 
 import com.fc.projectboard.domain.Article;
+import com.fc.projectboard.domain.Hashtag;
 import com.fc.projectboard.domain.UserAccount;
 import com.fc.projectboard.domain.constant.SearchType;
 import com.fc.projectboard.dto.ArticleDto;
 import com.fc.projectboard.dto.ArticleWithCommentsDto;
 import com.fc.projectboard.repository.ArticleRepository;
+import com.fc.projectboard.repository.HashtagRepository;
 import com.fc.projectboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,8 +28,10 @@ import java.util.List;
 @Service
 public class ArticleService {
 
+    private final HashtagService hashtagService;
     private final ArticleRepository articleRepository;
     private final UserAccountRepository userAccountRepository;
+    private final HashtagRepository hashtagRepository;
 
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
@@ -36,8 +42,10 @@ public class ArticleService {
         return switch (searchType) {
             case TITLE -> articleRepository.findByTitleContaining(searchKeyword, pageable).map(ArticleDto::from);
             case CONTENT -> articleRepository.findByContentContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case ID -> articleRepository.findByUserAccount_UserIdContaining(searchKeyword, pageable).map(ArticleDto::from);
-            case NICKNAME -> articleRepository.findByUserAccount_NicknameContaining(searchKeyword, pageable).map(ArticleDto::from);
+            case ID ->
+                    articleRepository.findByUserAccount_UserIdContaining(searchKeyword, pageable).map(ArticleDto::from);
+            case NICKNAME ->
+                    articleRepository.findByUserAccount_NicknameContaining(searchKeyword, pageable).map(ArticleDto::from);
             case HASHTAG -> articleRepository.findByHashtagNames(
                             Arrays.stream(searchKeyword.split(" ")).toList(),
                             pageable
@@ -62,7 +70,29 @@ public class ArticleService {
 
     public void saveArticle(ArticleDto dto) {
         UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-        articleRepository.save(dto.toEntity(userAccount));
+        // articleRepository.save(dto.toEntity(userAccount));
+        Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+
+        Article article = dto.toEntity(userAccount);
+        article.addHashtags(hashtags);
+        articleRepository.save(article);
+    }
+
+    private Set<Hashtag> renewHashtagsFromContent(String content) {
+        Set<String> hashtagNamesInContent = hashtagService.parseHashtagNames(content);
+        Set<Hashtag> hashtags = hashtagService.findHashtagsByNames(
+                hashtagNamesInContent
+        );
+        Set<String> existingHashtagNames = hashtags.stream()
+                .map(Hashtag::getHashtagName)
+                .collect(Collectors.toUnmodifiableSet());
+
+        hashtagNamesInContent.forEach(newHashtagName -> {
+            if (!existingHashtagNames.contains(newHashtagName)) {
+                hashtags.add(Hashtag.of(newHashtagName));
+            }
+        });
+        return hashtags;
     }
 
     public void updateArticle(Long articleId, ArticleDto dto) {
@@ -71,8 +101,24 @@ public class ArticleService {
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
             if (article.getUserAccount().equals(userAccount)) {
-                if (dto.title() != null) { article.setTitle(dto.title()); }
-                if (dto.content() != null) { article.setContent(dto.content()); }
+                if (dto.title() != null) {
+                    article.setTitle(dto.title());
+                }
+                if (dto.content() != null) {
+                    article.setContent(dto.content());
+                }
+
+                Set<Long> hashtagIds = article.getHashtags().stream()
+                        .map(Hashtag::getId)
+                        .collect(Collectors.toUnmodifiableSet());
+                article.clearHashtags();
+                articleRepository.flush();
+
+                hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
+
+                Set<Hashtag> hashtags = renewHashtagsFromContent(dto.content());
+                article.addHashtags(hashtags);
+
             }
         } catch (EntityNotFoundException e) {
             log.warn("게시글 업데이트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
@@ -80,7 +126,16 @@ public class ArticleService {
     }
 
     public void deleteArticle(long articleId, String userId) {
+        // articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
+        Article article = articleRepository.getReferenceById(articleId);
+        Set<Long> hashtagIds = article.getHashtags().stream()
+                .map(Hashtag::getId)
+                .collect(Collectors.toUnmodifiableSet());
+
         articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
+        articleRepository.flush();
+
+        hashtagIds.forEach(hashtagService::deleteHashtagWithoutArticles);
     }
 
     public long getArticleCount() {
@@ -88,16 +143,18 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
-        if (hashtag == null || hashtag.isBlank()) {
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtagName, Pageable pageable) {
+        if (hashtagName == null || hashtagName.isBlank()) {
             return Page.empty(pageable);
         }
 
-        return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        // return articleRepository.findByHashtagNames(null, pageable).map(ArticleDto::from);
+        return articleRepository.findByHashtagNames(List.of(hashtagName), pageable)
+                .map(ArticleDto::from);
     }
 
     public List<String> getHashtags() {
-        return articleRepository.findAllDistinctHashtags();
+        return hashtagRepository.findAllHashtagNames(); //TODO: HashtagService 로 이동을 고려해보자. findAllDistinctHashtags();
     }
 
 }

--- a/src/main/java/com/fc/projectboard/service/HashtagService.java
+++ b/src/main/java/com/fc/projectboard/service/HashtagService.java
@@ -1,21 +1,49 @@
 package com.fc.projectboard.service;
 
+import com.fc.projectboard.domain.Hashtag;
+import com.fc.projectboard.repository.HashtagRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class HashtagService {
 
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    public HashtagService(HashtagRepository hashtagRepository) {
+        this.hashtagRepository = hashtagRepository;
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<String> parseHashtagNames(String content) {
+        if(content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher= pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+        return Set.copyOf(result);
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    @Transactional(readOnly = true)
+    public Set<Hashtag> findHashtagsByNames(Set<String> expectedHashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(expectedHashtagNames));
+    }
+
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if(hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
 
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -32,7 +32,7 @@
                 <p>
                     <time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time>
                 </p>
-                <p><span id="hashtag">#java</span></p>
+                <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -1,34 +1,43 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header" />
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#footer" th:replace="footer :: footer"/>
 
     <attr sel="#article-main" th:object="${article}">
-        <attr sel="#article-header/h1" th:text="*{title}" />
-        <attr sel="#nickname" th:text="*{nickname}" />
-        <attr sel="#email" th:text="*{email}" />
-        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
-        <attr sel="#article-content/pre" th:text="*{content}" />
+        <attr sel="#article-header/h1" th:text="*{title}"/>
+        <attr sel="#nickname" th:text="*{nickname}"/>
+        <attr sel="#email" th:text="*{email}"/>
+        <attr sel="#created-at" th:datetime="*{createdAt}"
+              th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag}, searchValue=${hashtag})}"
+            />
+        </attr>
+        <attr sel="#article-content/pre" th:text="*{content}"/>
 
-        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
+        <attr sel="#article-buttons"
+              th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
-                <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
+                <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'"/>
             </attr>
         </attr>
 
-        <attr sel=".article-id" th:name="articleId" th:value="*{id}" />
+        <attr sel=".article-id" th:name="articleId" th:value="*{id}"/>
         <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
-            <attr sel="#comment-textbox" th:name="content" />
+            <attr sel="#comment-textbox" th:name="content"/>
         </attr>
 
         <attr sel="#article-comments" th:remove="all-but-first">
             <attr sel="li[0]" th:each="articleComment : ${articleComments}">
                 <attr sel="form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
-                    <attr sel="div/strong" th:text="${articleComment.nickname}" />
-                    <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-                    <attr sel="div/p" th:text="${articleComment.content}" />
-                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
+                    <attr sel="div/strong" th:text="${articleComment.nickname}"/>
+                    <attr sel="div/small/time" th:datetime="${articleComment.createdAt}"
+                          th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
+                    <attr sel="div/p" th:text="${articleComment.content}"/>
+                    <attr sel="button"
+                          th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}"/>
                 </attr>
             </attr>
         </attr>

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
         <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
       </div>
     </div>
-    <div class="row mb-4 justify-content-md-center">
-      <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-      <div class="col-sm-8 col-lg-9">
-        <input type="text" class="form-control" id="hashtag" name="hashtag">
-      </div>
-    </div>
     <div class="row mb-5 justify-content-md-center">
       <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
         <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -70,7 +70,7 @@
             <tbody>
             <tr>
                 <td class="title"><a>첫글</a></td>
-                <td class="hashtag">#java</td>
+                <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                 <td class="user-id">Uno</td>
                 <td class="created-at"><time>2022-01-01</time></td>
             </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header" />
-    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="#header" th:replace="header :: header"/>
+    <attr sel="#footer" th:replace="footer :: footer"/>
 
     <attr sel="main" th:object="${articles}">
-        <attr sel="#search-form" th:action="@{/articles}" th:method="get" />
+        <attr sel="#search-form" th:action="@{/articles}" th:method="get"/>
         <attr sel="#search-type" th:remove="all-but-first">
             <attr sel="option[0]"
                   th:each="searchType : ${searchTypes}"
@@ -13,7 +13,7 @@
                   th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"
             />
         </attr>
-        <attr sel="#search-value" th:value="${param.searchValue}" />
+        <attr sel="#search-value" th:value="${param.searchValue}"/>
 
         <attr sel="#article-table">
             <attr sel="thead/tr">
@@ -25,7 +25,7 @@
         )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
-            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
             searchType=${param.searchType},
             searchValue=${param.searchValue}
         )}"/>
@@ -45,15 +45,20 @@
 
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
-                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                    <attr sel="td.hashtag" th:text="${article.hashtag}" />
-                    <attr sel="td.user-id" th:text="${article.nickname}" />
-                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag}, searchValue=${hashtag})}"/>
+                    </attr>
+                    <attr sel="td.user-id" th:text="${article.nickname}"/>
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}"
+                          th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
                 </attr>
             </attr>
         </attr>
 
-        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}"/>
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
@@ -1,0 +1,106 @@
+package com.fc.projectboard.service;
+
+import com.fc.projectboard.domain.Hashtag;
+import com.fc.projectboard.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+        // Given
+
+        // When
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        // Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+}


### PR DESCRIPTION
게시글에 달린 해시태그를 관리하기 위한 기능을 구현.
독특하게도 해시태그의 저장을 다루는 메소드가 없는데
해시태그의 저장은 현재 비즈니스 로직의 구조 상
게시글이 저장, 수정될 때만 일어나는 기능으로
연관관계 매핑을 통해 게시글 서비스에서 모두 처리가 되기 때문.

* 해시태그 이름으로 해시태그 정보를 db 조회하기
* 본문에서 해시태그 파싱하기
* 게시글이 더 이상 없는 해시태그를 삭제하기

이 정보는 뷰에서 해시태그에 링크를 달 때
게시글의 검색 필터 정보로 쓰기 위해 필요하다.

* 게시글 페이지, 게시판 페이지: 해시태그에 링크를 달고, badge 스타일을 추가
* 게시글 추가 페이지: 해시태그 입력칸 삭제